### PR TITLE
support $(command) substitution in labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Enter a name and command for each entry to include it in the drop-down menu.
 - For sudo commands that require a password, use `pkexec` before the command to get a password prompt. For example, `pkexec sudo command` prompts for your password and then runs the command. Alternatively, use `gnome-terminal -- sudo command` to open a terminal where you can enter your password.
 - To open the command configuration window for this extension directly, use the command `gnome-extensions prefs custom-command-list@storageb.github.com`.
 
+**Dynamic labels:**
+- Use `$(command)` in a name to substitute the output of a command. For example, `---$(hostname)` shows the hostname as a separator label.
+- Commands that take longer than 2 seconds are cancelled.
+
 ### Icons
 
 Enter the name of a system icon. 

--- a/extension.js
+++ b/extension.js
@@ -29,6 +29,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';
 
@@ -138,8 +139,9 @@ class CommandMenu extends PanelMenu.Button {
                     style_class: 'section-label-menu-item',
                 });
 
+                const labelText = entryRowA.trimStart().slice(matchingSeparator.length).trim();
                 const label = new St.Label({
-                    text: this._resolveLabel(entryRowA.trimStart().slice(matchingSeparator.length).trim()),
+                    text: labelText,
                     style_class: 'popup-subtitle-menu-item',
                     x_expand: true,
                     x_align: Clutter.ActorAlign.START,
@@ -147,6 +149,7 @@ class CommandMenu extends PanelMenu.Button {
                 });
 
                 label.set_style('font-size: 0.8em; padding: 0em; margin: 0em; line-height: 1em;');
+                this._resolveLabelAsync(label, labelText);
                 sectionLabel.actor.set_style('padding-top: 0px; padding-bottom: 0px; min-height: 0;');
                 sectionLabel.actor.add_child(label);
 
@@ -181,25 +184,45 @@ class CommandMenu extends PanelMenu.Button {
     }
 
 
-    _resolveLabel(label) {
-        // Dynamic: $(command) - runs a shell command and substitutes stdout
-        label = label.replace(/\$\(([^)]+)\)/g, (_match, cmd) => {
+    _resolveLabelAsync(labelWidget, text) {
+        const pattern = /\$\(([^)]+)\)/g;
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const fullMatch = match[0];
+            const cmd = match[1];
+            console.log(`[Custom Command Menu] Resolving dynamic label: ${cmd}`);
+            const cancellable = new Gio.Cancellable();
+            const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 2, () => {
+                console.log(`[Custom Command Menu] Timeout for: ${cmd}`);
+                cancellable.cancel();
+                return GLib.SOURCE_REMOVE;
+            });
             try {
-                let [ok, stdout] = GLib.spawn_command_line_sync(`timeout 1 ${cmd}`);
-                if (ok && stdout) {
-                    return new TextDecoder().decode(stdout).trim();
-                }
+                const proc = Gio.Subprocess.new(
+                    ['sh', '-c', cmd],
+                    Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE
+                );
+                proc.communicate_utf8_async(null, cancellable, (proc, res) => {
+                    GLib.source_remove(timeoutId);
+                    try {
+                        const [, stdout] = proc.communicate_utf8_finish(res);
+                        console.log(`[Custom Command Menu] Got output for ${cmd}: '${stdout}'`);
+                        if (stdout) {
+                            const current = labelWidget.get_text();
+                            labelWidget.set_text(current.replace(fullMatch, stdout.trim()));
+                        }
+                    } catch (e) {
+                        console.log(`[Custom Command Menu] Error resolving dynamic label: ${cmd}: ${e}`);
+                    }
+                });
             } catch (e) {
-                console.log(`[Custom Command Menu] Error resolving dynamic label: ${cmd}: ${e}`);
+                GLib.source_remove(timeoutId);
+                console.log(`[Custom Command Menu] Error spawning command: ${cmd}: ${e}`);
             }
-            return _match;
-        });
-
-        return label;
+        }
     }
 
     _addMenuItem(label, command, icon, targetMenu = this.menu) {
-        label = this._resolveLabel(label);
         let newItem = new PopupMenu.PopupMenuItem('');
         if (icon) {
             let commandIcon = new St.Icon({
@@ -210,6 +233,7 @@ class CommandMenu extends PanelMenu.Button {
         }
         let commandLabel = new St.Label({ text: label });
         newItem.add_child(commandLabel);
+        this._resolveLabelAsync(commandLabel, label);
         
         newItem.connect('activate', () => {
             // Run associated command when a menu item is clicked

--- a/extension.js
+++ b/extension.js
@@ -44,6 +44,8 @@ class CommandMenu extends PanelMenu.Button {
 
     constructor(mySettings) {
         super(0.5, _('Commands'));
+        this._pendingTimeouts = [];
+        this._pendingCancellables = [];
         let labelText;
 
         if (mySettings.get_int('menuoptions-setting') === 2) {
@@ -184,6 +186,16 @@ class CommandMenu extends PanelMenu.Button {
     }
 
 
+    destroy() {
+        for (const id of this._pendingTimeouts)
+            GLib.source_remove(id);
+        for (const c of this._pendingCancellables)
+            c.cancel();
+        this._pendingTimeouts = [];
+        this._pendingCancellables = [];
+        super.destroy();
+    }
+
     _resolveLabelAsync(labelWidget, text) {
         const pattern = /\$\(([^)]+)\)/g;
         let match;
@@ -191,10 +203,12 @@ class CommandMenu extends PanelMenu.Button {
             const fullMatch = match[0];
             const cmd = match[1];
             const cancellable = new Gio.Cancellable();
+            this._pendingCancellables.push(cancellable);
             const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 2, () => {
                 cancellable.cancel();
                 return GLib.SOURCE_REMOVE;
             });
+            this._pendingTimeouts.push(timeoutId);
             try {
                 const proc = Gio.Subprocess.new(
                     ['sh', '-c', cmd],

--- a/extension.js
+++ b/extension.js
@@ -190,10 +190,8 @@ class CommandMenu extends PanelMenu.Button {
         while ((match = pattern.exec(text)) !== null) {
             const fullMatch = match[0];
             const cmd = match[1];
-            console.log(`[Custom Command Menu] Resolving dynamic label: ${cmd}`);
             const cancellable = new Gio.Cancellable();
             const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 2, () => {
-                console.log(`[Custom Command Menu] Timeout for: ${cmd}`);
                 cancellable.cancel();
                 return GLib.SOURCE_REMOVE;
             });
@@ -206,7 +204,6 @@ class CommandMenu extends PanelMenu.Button {
                     GLib.source_remove(timeoutId);
                     try {
                         const [, stdout] = proc.communicate_utf8_finish(res);
-                        console.log(`[Custom Command Menu] Got output for ${cmd}: '${stdout}'`);
                         if (stdout) {
                             const current = labelWidget.get_text();
                             labelWidget.set_text(current.replace(fullMatch, stdout.trim()));

--- a/extension.js
+++ b/extension.js
@@ -139,7 +139,7 @@ class CommandMenu extends PanelMenu.Button {
                 });
 
                 const label = new St.Label({
-                    text: entryRowA.trimStart().slice(matchingSeparator.length).trim(),
+                    text: this._resolveLabel(entryRowA.trimStart().slice(matchingSeparator.length).trim()),
                     style_class: 'popup-subtitle-menu-item',
                     x_expand: true,
                     x_align: Clutter.ActorAlign.START,
@@ -181,7 +181,25 @@ class CommandMenu extends PanelMenu.Button {
     }
 
 
+    _resolveLabel(label) {
+        // Dynamic: $(command) - runs a shell command and substitutes stdout
+        label = label.replace(/\$\(([^)]+)\)/g, (_match, cmd) => {
+            try {
+                let [ok, stdout] = GLib.spawn_command_line_sync(cmd);
+                if (ok && stdout) {
+                    return new TextDecoder().decode(stdout).trim();
+                }
+            } catch (e) {
+                console.log(`[Custom Command Menu] Error resolving dynamic label: ${cmd}: ${e}`);
+            }
+            return _match;
+        });
+
+        return label;
+    }
+
     _addMenuItem(label, command, icon, targetMenu = this.menu) {
+        label = this._resolveLabel(label);
         let newItem = new PopupMenu.PopupMenuItem('');
         if (icon) {
             let commandIcon = new St.Icon({

--- a/extension.js
+++ b/extension.js
@@ -211,7 +211,7 @@ class CommandMenu extends PanelMenu.Button {
             this._pendingTimeouts.push(timeoutId);
             try {
                 const proc = Gio.Subprocess.new(
-                    ['/usr/bin/env', 'bash', '-c', cmd],
+                    ['bash', '-c', cmd],
                     Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE
                 );
                 proc.communicate_utf8_async(null, cancellable, (proc, res) => {

--- a/extension.js
+++ b/extension.js
@@ -211,7 +211,7 @@ class CommandMenu extends PanelMenu.Button {
             this._pendingTimeouts.push(timeoutId);
             try {
                 const proc = Gio.Subprocess.new(
-                    ['sh', '-c', cmd],
+                    ['/usr/bin/env', 'bash', '-c', cmd],
                     Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE
                 );
                 proc.communicate_utf8_async(null, cancellable, (proc, res) => {

--- a/extension.js
+++ b/extension.js
@@ -185,7 +185,7 @@ class CommandMenu extends PanelMenu.Button {
         // Dynamic: $(command) - runs a shell command and substitutes stdout
         label = label.replace(/\$\(([^)]+)\)/g, (_match, cmd) => {
             try {
-                let [ok, stdout] = GLib.spawn_command_line_sync(cmd);
+                let [ok, stdout] = GLib.spawn_command_line_sync(`timeout 1 ${cmd}`);
                 if (ok && stdout) {
                     return new TextDecoder().decode(stdout).trim();
                 }


### PR DESCRIPTION
Adds support for `$(command)` in label text. The command runs at menu render time and the output replaces the expression. For example a label set to "---$(hostname)" shows the machine hostname as a section header. Works in regular items and labeled separators.
<img width="297" height="493" alt="image" src="https://github.com/user-attachments/assets/ffbd8896-082e-455c-9dad-a910366832fa" />
