### PR TITLE
feat: Add special command to open application overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Enter a name and command for each entry to include it in the drop-down menu.
 - Use `$(command)` in a name to substitute the output of a command. For example, `---$(hostname)` shows the hostname as a separator label.
 - Commands that take longer than 2 seconds are cancelled.
 
+**Special commands:**
+- Use `##ShowApplications;` as a command to open the GNOME applications view.
+
 ### Icons
 
 Enter the name of a system icon. 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Enter a name and command for each entry to include it in the drop-down menu.
 - Commands that take longer than 2 seconds are cancelled.
 
 **Special commands:**
-- Use `##ShowApplications;` as a command to open the GNOME applications view.
+- Use `##ShowApplications` as a command to open the GNOME applications view.
 
 ### Icons
 

--- a/extension.js
+++ b/extension.js
@@ -28,6 +28,7 @@ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/ex
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as OverviewControls from 'resource:///org/gnome/shell/ui/overviewControls.js';
 
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
@@ -250,6 +251,11 @@ class CommandMenu extends PanelMenu.Button {
         this._resolveLabelAsync(commandLabel, label);
         
         newItem.connect('activate', () => {
+            if (command === '##ShowApplications;') {
+                Main.overview.show(OverviewControls.ControlsState.APP_GRID);
+                return;
+            }
+
             // Run associated command when a menu item is clicked
             console.log(_('[Custom Command Menu] Attempting to execute command:\n%s').replace('%s', command));
             let [success, pid] = GLib.spawn_async(null, ["/usr/bin/env", "bash", "-c", command], null, GLib.SpawnFlags.SEARCH_PATH, null);

--- a/extension.js
+++ b/extension.js
@@ -251,7 +251,7 @@ class CommandMenu extends PanelMenu.Button {
         this._resolveLabelAsync(commandLabel, label);
         
         newItem.connect('activate', () => {
-            if (command === '##ShowApplications;') {
+            if (command.trim().toLowerCase() === '##showapplications') {
                 Main.overview.show(OverviewControls.ControlsState.APP_GRID);
                 return;
             }


### PR DESCRIPTION
Introduces `##ShowApplications;` as a special command to display the GNOME applications grid. This is something Bazzite's existing logo menu does. I used `Main.overview.show(OverviewControls.ControlsState.APP_GRID);`, which is the exact line Dash to Dock uses to trigger the application grid.
